### PR TITLE
use Jammit.public_root if defined to support Jammit 0.6.5

### DIFF
--- a/lib/jammit/middleware.rb
+++ b/lib/jammit/middleware.rb
@@ -10,6 +10,7 @@ module Jammit
 
     SUFFIX_STRIPPER = /-(datauri|mhtml)\Z/
 
+    PUBLIC_ROOT     = defined?(Jammit.public_root) ? Jammit.public_root : PUBLIC_ROOT
     NOT_FOUND_PATH  = "#{PUBLIC_ROOT}/404.html"
 
     def initialize(app)


### PR DESCRIPTION
Jammit version 0.6.5 changed how it sets the public root directory. I just updated middleware.rb to use the new way if defined, Jammit.public_root, otherwise it uses the old PUBLIC_ROOT.
